### PR TITLE
Updated project to be compatible with VS2010 and .NET 4.0

### DIFF
--- a/RexProClient.Tests/RexProClient.Tests.csproj
+++ b/RexProClient.Tests/RexProClient.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rexster.Tests</RootNamespace>
     <AssemblyName>Rexster.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -70,7 +70,7 @@
   <ItemGroup>
     <ProjectReference Include="..\RexProClient\RexProClient.csproj">
       <Project>{9CCE3553-758A-493C-BB8F-157648E05DF4}</Project>
-      <Name>RexsterClient</Name>
+      <Name>RexProClient</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/RexProClient/RexProClient.csproj
+++ b/RexProClient/RexProClient.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rexster</RootNamespace>
     <AssemblyName>RexProClient</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -38,8 +38,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="MsgPack">
-      <HintPath>..\packages\MsgPack.Cli.0.3\lib\net40-client\MsgPack.dll</HintPath>
+    <Reference Include="MsgPack, Version=0.3.0.0, Culture=neutral, PublicKeyToken=a2625990d5dc0167, processorArchitecture=MSIL">
+      <HintPath>..\packages\MsgPack.Cli.0.3.1\lib\net40-client\MsgPack.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/RexProClient/packages.config
+++ b/RexProClient/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MsgPack.Cli" version="0.3" targetFramework="net45" />
+  <package id="MsgPack.Cli" version="0.3.1" targetFramework="net40" />
 </packages>

--- a/Rexster.sln
+++ b/Rexster.sln
@@ -1,6 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RexProClient", "RexProClient\RexProClient.csproj", "{9CCE3553-758A-493C-BB8F-157648E05DF4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RexProClient.Tests", "RexProClient.Tests\RexProClient.Tests.csproj", "{97F15C87-36DD-4AD4-B95E-41395A21957A}"
@@ -12,7 +12,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{335EFB
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{39246A5D-2ABB-4EF2-9339-8FA640154215}"
+	ProjectSection(SolutionItems) = preProject
+		Rexster.vsmdi = Rexster.vsmdi
+	EndProjectSection
+EndProject
 Global
+	GlobalSection(TestCaseManagementSettings) = postSolution
+		CategoryFile = Rexster.vsmdi
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU


### PR DESCRIPTION
The projects in the RexPro Client solution would not load in VS 2010. You get an error message about compatibility. 

NuGet produces an error if you try to install using .NET 4.0:

```
Attempting to resolve dependency 'MsgPack.Cli (≥ 0.3)'.
Installing 'MsgPack.Cli 0.3.1'.
Successfully installed 'MsgPack.Cli 0.3.1'.
Installing 'RexProClient 1.0.4864.22416'.
Successfully installed 'RexProClient 1.0.4864.22416'.
Adding 'MsgPack.Cli 0.3.1' to Fabric.Api.Traversal.
'packages.config' already exists. Skipping...
Successfully added 'MsgPack.Cli 0.3.1' to Fabric.Api.Traversal.
Adding 'RexProClient 1.0.4864.22416' to Fabric.Api.Traversal.
Uninstalling 'RexProClient 1.0.4864.22416'.
Successfully uninstalled 'RexProClient 1.0.4864.22416'.
Successfully uninstalled 'MsgPack.Cli 0.3.1'.
Install failed. Rolling back...
Could not install package 'RexProClient 1.0.4864.22416'. You are trying to install this package into a project that targets '.NETFramework,Version=v4.0', but the package does not contain any assembly references or content files that are compatible with that framework. For more information, contact the package author.
```

This commit resolves the VS 2010 issue. I'm not sure if it will fix the NuGet issue. All 27 tests pass, so it doesn't seem that using .NET 4.5 was a necessity.
