### PR TITLE
Added support for custom TcpClients

### DIFF
--- a/RexProClient/RexProClient.cs
+++ b/RexProClient/RexProClient.cs
@@ -120,7 +120,6 @@
         }
 
         private TcpClient NewTcpClient() {
-            System.Console.WriteLine("NEW CLIENT: "+tcpClientProvider+" / "+host+" / "+port);
             return (tcpClientProvider != null ? 
                 tcpClientProvider() : new TcpClient(this.host, this.port));
         }


### PR DESCRIPTION
This allows a RexProClient user to supply their TcpClients from a connection pool and/or apply their own connection settings.

All 27 tests pass. I didn't add any tests for this, but I did give it some successful trial runs in my Fabric project.
