### PR TITLE
Removed hard-coded values for graphName and graphObjName

### DIFF
--- a/RexProClient/Messages/ScriptRequestMetaData.cs
+++ b/RexProClient/Messages/ScriptRequestMetaData.cs
@@ -14,8 +14,6 @@ namespace Rexster.Messages
         {
             this.isolate = true;
             this.transaction = true;
-            this.graphName = "graph";
-            this.graphObjName = "g";
         }
 
         public bool InSession


### PR DESCRIPTION
The graphName and graphObjName fields on the GraphSettings object are currently ignored because of the values set in the ScriptRequestMetaData constructor.  Removing them allows arbitrary named graphs from the Rexster configuration to be used (instead of just those named "graph").

I could have added a test of the RexProClient constructor with a GraphSettings object, however I wasn't sure about introducing a dependency on a given graph being named in the Rexster configuration.
